### PR TITLE
fix: add thread count for ycsb-redis

### DIFF
--- a/internal/controller/ycsb_job.go
+++ b/internal/controller/ycsb_job.go
@@ -40,7 +40,7 @@ func NewYscbCleanupJobs(cr *v1alpha1.Ycsb) []*batchv1.Job {
 
 func NewYcsbPrepareJobs(cr *v1alpha1.Ycsb) []*batchv1.Job {
 	cmd := "/go-ycsb"
-	cmd = fmt.Sprintf("%s load %s", cmd, cr.Spec.Target.Driver)
+	cmd = fmt.Sprintf("%s load %s --interval 1", cmd, cr.Spec.Target.Driver)
 	cmd = fmt.Sprintf("%s %s", cmd, NewYcsbWorkloadParams(cr))
 	cmd = fmt.Sprintf("%s -p recordcount=%d", cmd, cr.Spec.RecordCount)
 	cmd = fmt.Sprintf("%s -p operationcount=%d", cmd, cr.Spec.OperationCount)

--- a/internal/controller/ycsb_job.go
+++ b/internal/controller/ycsb_job.go
@@ -44,6 +44,7 @@ func NewYcsbPrepareJobs(cr *v1alpha1.Ycsb) []*batchv1.Job {
 	cmd = fmt.Sprintf("%s %s", cmd, NewYcsbWorkloadParams(cr))
 	cmd = fmt.Sprintf("%s -p recordcount=%d", cmd, cr.Spec.RecordCount)
 	cmd = fmt.Sprintf("%s -p operationcount=%d", cmd, cr.Spec.OperationCount)
+	cmd = fmt.Sprintf("%s -p threadcount=%d", cmd, cr.Spec.Threads[0])
 	cmd = fmt.Sprintf("%s %s", cmd, strings.Join(cr.Spec.ExtraArgs, " "))
 	cmd = fmt.Sprintf("%s 2>&1 | tee /var/log/ycsb.log", cmd)
 


### PR DESCRIPTION
when ycsb on redis, the `threadcount` is necessary